### PR TITLE
input: let Space open doors instead of firing

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -35,8 +35,8 @@ For continuous firing, click repeatedly - buttons use a 50ms release delay match
 
 | Key | Action |
 |-----|--------|
-| Space, F, I | Fire weapon (any of these keys work) |
-| E | Use / Open doors / Activate switches |
+| F, I | Fire weapon (either key works) |
+| Space, E | Use / Open doors / Activate switches |
 | Right Alt | Strafe mode (hold to strafe with arrow keys) |
 | Right Shift | Run (hold to move faster) |
 
@@ -105,7 +105,7 @@ In multiplayer games, press the following keys to send messages to specific play
 
 1. Arrow keys automatically stay pressed when held - smooth continuous movement without lag.
 2. Use mouse for aiming - move the mouse to rotate view, left-click to fire.
-3. Use Space, F, or I keys to fire your weapon (easier than Ctrl in terminals).
+3. Use F or I keys to fire your weapon (easier than Ctrl in terminals).
 4. The game runs at 35 FPS (original DOOM timing).
 5. Press ESC to access the menu at any time.
 6. Press F11 to cycle through brightness levels if the game is too dark.

--- a/src/input.c
+++ b/src/input.c
@@ -251,7 +251,7 @@ static bool is_key_held(input_t *restrict input, int key)
 
 static bool is_fire_key(int key)
 {
-    return key == ' ' || key == 'f' || key == 'F' || key == 'i' || key == 'I';
+    return key == 'f' || key == 'F' || key == 'i' || key == 'I';
 }
 
 static void ascii_key(input_t *restrict input, char ch)


### PR DESCRIPTION
With the kitty keyboard protocol active, bare Ctrl is reported natively (KKP_LEFT_CTRL -> fire), so remapping Space to fire is unnecessary -- and it left "use/open door" unreachable from the keyboard: Doom binds 'use' to Space by default, so only right-click (which injects Space) could open doors.

Stop treating Space as fire in dispatch_kkp_key so it passes through as Space and triggers Doom's use action. Fire stays on Ctrl, F, and I. The legacy ascii_key path is unchanged -- it still treats Space as fire, since without the kitty protocol it cannot send a bare Ctrl.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Under the kitty keyboard protocol, Space now reaches Doom’s use action instead of being remapped to fire, so doors and switches can be opened from the keyboard. Fire stays on bare Ctrl and F/I; the legacy `ascii_key` path still treats Space as fire. `USAGE.md` is updated to match.

<sup>Written for commit 245d673526d3089a1d7cbdb74f9af8e7b1bc36e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jserv/kitty-doom/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

