### PR TITLE
build: fix broken resourse link in external.mk

### DIFF
--- a/mk/external.mk
+++ b/mk/external.mk
@@ -19,21 +19,32 @@ else
     SHA256_CMD =
 endif
 
+
 # DOOM1.WAD (shareware version)
 # Note: PureDOOM expects lowercase "doom1.wad" on case-sensitive filesystems (Linux).
 # The Makefile will create a symlink automatically via the check-wad-symlink target.
-DOOM1_WAD_URL = https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad
+DOOM1_ZIP_URL = https://archive.org/download/doom-wads/Doom%20%28v1.9%29.zip
+DOOM1_ZIP = doom1.zip
 DOOM1_WAD = DOOM1.WAD
-DOOM1_WAD_SHA256 = 1d7d43be501e67d927e415e0b8f3e29c3bf33075e859721816f652a526cac771
+DOOM1_WAD_SHA256 = ff2c301b8719465a6e386a512bfa319931b7f64ea517d337c5a47afe03951902
 
-$(DOOM1_WAD):
+$(DOOM1_ZIP):
 	$(VECHO) "  GET\t$@\n"
-	$(Q)$(DOWNLOAD_CMD) $@ $(DOOM1_WAD_URL)
+	$(Q)$(DOWNLOAD_CMD) $@ $(DOOM1_ZIP_URL)
+
+$(DOOM1_WAD): $(DOOM1_ZIP)
+	$(VECHO) "  UNZIP\t$@\n"
+	$(Q)unzip -q -o -j $< "DOOM.WAD" -d .    
+	$(Q)mv DOOM.WAD $@
+    
 ifdef SHA256_CMD
 	$(VECHO) "  CHK\t$@ (SHA256)\n"
 	$(Q)echo "$(DOOM1_WAD_SHA256)  $@" | $(SHA256_CMD) >/dev/null || \
 		{ echo "Error: Checksum mismatch for $@"; rm -f "$@"; false; }
 endif
+	$(VECHO) "  RM\t$<\n"
+	$(Q)rm -f $<
+
 
 # PureDOOM.h download rule
 PUREDOOM_URL = https://raw.githubusercontent.com/Daivuk/PureDOOM/master/PureDOOM.h


### PR DESCRIPTION
### Description
This PR resolves an issue where a resource URL in the build configuration was failing to load.
It updated the broken target URL in `mk/external.mk` to point to the an active endpoint, which is confirmed to be resolved successfully.

### Related Issues
* Fixes #12 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the dead DOOM1.WAD URL in mk/external.mk with a working archive.org source and switches from direct WAD download to downloading a zip, extracting DOOM.WAD to DOOM1.WAD, verifying a new SHA256, and removing the zip. Restores reliable asset retrieval for the build.

- Output artifact remains DOOM1.WAD; downstream targets and symlink logic are unchanged.
- Adds an intermediate DOOM1_ZIP file that the rule deletes after verification.
- Build now requires `unzip`; install it in CI and developer environments.

<sup>Written for commit 71a885a4eb0cc6bdf48af7afd6b06657c96134d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jserv/kitty-doom/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

