### PR TITLE
render: send C=1 on the initial placement so the frame is not clipped

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -150,7 +150,11 @@ void renderer_render_frame(renderer_t *restrict r,
         if (encoded_offset == 0) {
             /* First chunk includes all image metadata */
             if (r->frame_number == 0) {
-                /* First frame: create new image */
+                /* First frame: create new image.
+                 * C=1 keeps the cursor at home after placement. Without it
+                 * the terminal advances the cursor past the full-screen
+                 * image, wraps, and scrolls the top rows off.
+                 */
                 header_len = snprintf(
                     buf + buf_offset, rem,
                     "\033_Ga=T,i=%ld,f=24,s=%d,v=%d,q=2,c=%d,r=%d,C=1,m=%d;",
@@ -236,16 +240,6 @@ void renderer_render_frame(renderer_t *restrict r,
             return;
         }
         buf_offset += (size_t) anim_len;
-    }
-
-    /* On first frame, add newline to move cursor below image */
-    if (r->frame_number == 0) {
-        if (buf_offset + KITTY_TRAILER_SIZE > r->protocol_buffer_size) {
-            fprintf(stderr, "ERROR: Newline overflow\n");
-            return;
-        }
-        memcpy(buf + buf_offset, "\r\n", KITTY_TRAILER_SIZE);
-        buf_offset += KITTY_TRAILER_SIZE;
     }
 
     /* Single batched write */

--- a/src/render.c
+++ b/src/render.c
@@ -153,7 +153,7 @@ void renderer_render_frame(renderer_t *restrict r,
                 /* First frame: create new image */
                 header_len = snprintf(
                     buf + buf_offset, rem,
-                    "\033_Ga=T,i=%ld,f=24,s=%d,v=%d,q=2,c=%d,r=%d,m=%d;",
+                    "\033_Ga=T,i=%ld,f=24,s=%d,v=%d,q=2,c=%d,r=%d,C=1,m=%d;",
                     r->kitty_id, WIDTH, HEIGHT, r->screen_cols, r->screen_rows,
                     more_chunks ? 1 : 0);
             } else {


### PR DESCRIPTION
Per the kitty graphics protocol — and kitty itself, below — a placement with C absent advances the cursor after display. Because kitty-doom sizes the image to c=screen_cols, exactly the terminal width, that advance wraps the cursor to the next line, which pushes it past the bottom margin and scrolls the screen. The top of the frame scrolls off and a blank band is left at the bottom.


Before, black band at bottom (image scrolled too high) and status messages missed:
<img width="1156" height="696" alt="image" src="https://github.com/user-attachments/assets/be2995de-1443-4243-8e8a-0cbdb888df5a" />

After, image sits snugly against the bottom of the terminal. No black band and status messages are visible:
<img width="1171" height="686" alt="image" src="https://github.com/user-attachments/assets/c6e53b4c-892c-4810-b3e2-63a9f246ac44" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the initial kitty graphics placement so the frame is not clipped. Sends `C=1` on the first placement to keep the cursor at home, preventing the cursor from advancing past the full-screen image and scrolling the screen. Also removes the first-frame trailing newline, which no longer serves a purpose now that `C=1` pins the cursor.

<sup>Written for commit f33884e214376a4c98a6f681ff3181178d569fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jserv/kitty-doom/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

