### PR TITLE
Update supported terminals in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Play the legendary first-person shooter in terminals that support the protocol.
 
 Supported Terminals
 - [Kitty](https://sw.kovidgoyal.net/kitty/) - Full support, best performance
+- [AbsoluteTelnet/SSH](https://www.celestialsoftware.net/doom-on-absolutetelnet-ssh/) - Full support, excellent performance, watch the video!
 
 ## Features
 


### PR DESCRIPTION
Added AbsoluteTelnet/SSH to the list of supported terminals.

See the video here:

https://www.celestialsoftware.net/doom-on-absolutetelnet-ssh/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AbsoluteTelnet/SSH to the supported terminals list in the README, noting its full support and performance.

<sup>Written for commit d9c97f49881d97435aa145f0bbb3d7b9a77f62cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jserv/kitty-doom/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

