### PR TITLE
Fix persistent tinted screen after taking damage or picking up bonus items

### DIFF
--- a/src/arch/neon-palette.h
+++ b/src/arch/neon-palette.h
@@ -39,7 +39,6 @@
 static uint8_t palette_r_neon[256] __attribute__((aligned(64)));
 static uint8_t palette_g_neon[256] __attribute__((aligned(64)));
 static uint8_t palette_b_neon[256] __attribute__((aligned(64)));
-static bool palette_initialized_neon = false;
 
 /* Split the packed RGB palette into separate R, G, B arrays for efficient SIMD
  * access patterns.
@@ -51,7 +50,6 @@ static inline void palette_init_neon(const uint8_t *restrict palette)
         palette_g_neon[i] = palette[i * 3 + 1];
         palette_b_neon[i] = palette[i * 3 + 2];
     }
-    palette_initialized_neon = true;
 }
 
 /* Convert indexed 8-bit palette data to RGB24 format using NEON SIMD.

--- a/src/main.c
+++ b/src/main.c
@@ -303,40 +303,12 @@ int main(int argc, char **argv)
          * interleaved stores. Scalar gather loop is unavoidable without
          * hardware gather instructions, but SIMD benefits come from optimized
          * RGB interleaving.
-         *
-         * Note: PureDOOM's screen_palette is initialized dynamically during
-         * gameplay. We check initialization status and use fallback conversion
-         * until palette is ready.
          */
-        static int palette_ready = -1; /* -1=unknown, 0=not ready, 1=ready */
-
-        /* Check palette initialization on first call */
-        if (palette_ready == -1) {
-            int sum = screen_palette[0] + screen_palette[1] + screen_palette[2];
-            palette_ready = (sum > 0) ? 1 : 0;
-        }
-
-        if (palette_ready) {
-            /* SIMD path: indexed → palette_to_rgb24 → RGB24 */
-            const unsigned char *indexed = doom_get_framebuffer(1);
-            PROFILE_START();
-            palette_to_rgb24(indexed, rgb24_buffer, screen_palette, npixels);
-            PROFILE_END("  Palette conversion");
-            renderer_render_frame(r, rgb24_buffer);
-        } else {
-            /* Fallback: Use PureDOOM's conversion until palette ready */
-            const unsigned char *rgb24 = doom_get_framebuffer(3);
-            renderer_render_frame(r, rgb24);
-
-            /* Recheck palette every 10 frames */
-            static int check_counter = 0;
-            if (++check_counter % 10 == 0) {
-                int sum =
-                    screen_palette[0] + screen_palette[1] + screen_palette[2];
-                if (sum > 0)
-                    palette_ready = 1;
-            }
-        }
+        const unsigned char *indexed = doom_get_framebuffer(1);
+        PROFILE_START();
+        palette_to_rgb24(indexed, rgb24_buffer, screen_palette, npixels);
+        PROFILE_END("  Palette conversion");
+        renderer_render_frame(r, rgb24_buffer);
     }
 
     /* Input thread is requested to exit before cleanup

--- a/src/palette.c
+++ b/src/palette.c
@@ -23,7 +23,9 @@
 static uint8_t palette_r_scalar[256] __attribute__((aligned(64)));
 static uint8_t palette_g_scalar[256] __attribute__((aligned(64)));
 static uint8_t palette_b_scalar[256] __attribute__((aligned(64)));
-static bool palette_initialized_scalar = false;
+
+static uint8_t cached_palette[256 * 3];
+static bool palette_initialized = false;
 
 __attribute__((unused)) static void palette_init_scalar(
     const uint8_t *restrict palette)
@@ -33,7 +35,6 @@ __attribute__((unused)) static void palette_init_scalar(
         palette_g_scalar[i] = palette[i * 3 + 1];
         palette_b_scalar[i] = palette[i * 3 + 2];
     }
-    palette_initialized_scalar = true;
 }
 
 __attribute__((unused)) static void palette_to_rgb24_scalar(
@@ -55,17 +56,24 @@ void palette_to_rgb24(const uint8_t *restrict indexed,
                       const uint8_t *restrict palette,
                       size_t npixels)
 {
+    if (!palette_initialized ||
+        memcmp(cached_palette, palette, sizeof(cached_palette)) != 0) {
+        memcpy(cached_palette, palette, sizeof(cached_palette));
+        palette_initialized = true;
+#if defined(__aarch64__) || defined(__ARM_NEON)
+        palette_init_neon(palette);
+#else
+        palette_init_scalar(palette);
+#endif
+    }
+
 #if defined(__aarch64__) || defined(__ARM_NEON)
     /* ARM NEON path: 1.5-1.8x speedup validated */
-    if (!palette_initialized_neon)
-        palette_init_neon(palette);
     palette_to_rgb24_neon_impl(indexed, rgb24, npixels);
 #else
     /* Scalar fallback: Used on x86_64 (compiler auto-vectorizes effectively)
      * and architectures without SIMD support.
      */
-    if (!palette_initialized_scalar)
-        palette_init_scalar(palette);
     palette_to_rgb24_scalar(indexed, rgb24, npixels);
 #endif
 }


### PR DESCRIPTION
Taking damage or picking up bonus items in DOOM triggers a visual palette shift. However, the screen would remain permanently tinted after taking damage and never decay back to the standard palette.
    
Fix this by:
- Adding dynamic palette change detection in palette.c via memcmp against a cached 768-byte palette, re-initializing planar channels only when the active palette actually changes.
- Removing redundant palette_initialized_neon flag in arch/neon-palette.h.
- Removing the flawed palette_ready check in main.c and invoking palette_to_rgb24() directly, as screen_palette is populated during doom_init().

Fix #18 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the persistent tinted screen after taking damage or picking up bonus items, which previously never decayed back to the standard palette.

- Detects palette changes with `memcmp` against a cached 768-byte palette, re-initializing planar channels only when the active palette actually changes.
- Removes the flawed `palette_ready` fallback in `main.c`; `screen_palette` is populated during `doom_init()`, so `palette_to_rgb24()` can be called directly.
- Removes the redundant `palette_initialized_neon` flag.

<sup>Written for commit 91e58f0e1eb9e283e1eec8385ecbca1c2bf444a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jserv/kitty-doom/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

